### PR TITLE
Фикс вызова мулботов ИИ

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -791,6 +791,7 @@ obj/machinery/bot/mulebot/bot_reset()
 		if(NB.location == new_destination)	// if the beacon location matches the set destination
 									// the we will navigate there
 			destination = new_destination
+			new_destination = null
 			target = NB.loc
 			var/direction = NB.dir	// this will be the load/unload dir
 			if(direction)

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -29,6 +29,11 @@
 </table>
 
 		<div class="commit sansserif">
+		<h2 class="date">8 December 2016</h2>
+		<h3 class="author">Jammer312 updated:</h3>
+		<ul class="changes bgimages16">
+			<li class="bugfix">Фикс непослушания при определенных условиях мулботов ИИ.</li>
+		</ul>
 		<h2 class="date">9 November 2016</h2>
 		<h3 class="author">Qwertyon666 updated:</h3>
 		<ul class="changes bgimages16">


### PR DESCRIPTION
До фикса если мулбота когда-либо вызывали через его интерфейс куда-либо, ИИ терял возможность посылать его куда-либо, кроме как через интерфейс, ибо new_destination не затиралось, и сразу же после вызова ИИ оно заменяло destination (определенный ИИ) на свое значение.
Имеется ввиду вызов через call (в панели ботов нажимаешь call, кликаешь по тайлу, куда зовешь) после вызова через интерфейс (выбор маяка, на который отправляется мулбот).