### PR TITLE
Переработка механизма перемещения по уровням.

### DIFF
--- a/code/__HELPERS/multiz.dm
+++ b/code/__HELPERS/multiz.dm
@@ -1,29 +1,27 @@
 proc/HasAbove(var/z)
 	var/turf/controllerlocation = locate(1, 1, z)
 	for(var/obj/effect/landmark/zcontroller/controller in controllerlocation)
-		if(controller.up)
-			return 1
+		return controller.up
 	return 0
 
 proc/HasBelow(var/z)
 	var/turf/controllerlocation = locate(1, 1, z)
 	for(var/obj/effect/landmark/zcontroller/controller in controllerlocation)
-		if(controller.down)
-			return 1
+		return controller.down
 	return 0
 
 proc/GetLevelAbove(var/z)
 	var/turf/controllerlocation = locate(1, 1, z)
 	for(var/obj/effect/landmark/zcontroller/controller in controllerlocation)
 		if(controller.up)
-			return controller.up
+			return controller.up_target
 	return 0
 
 proc/GetLevelBelow(var/z)
 	var/turf/controllerlocation = locate(1, 1, z)
 	for(var/obj/effect/landmark/zcontroller/controller in controllerlocation)
 		if(controller.down)
-			return controller.down
+			return controller.down_target
 	return 0
 
 proc/GetAbove(var/atom/atom)

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -17,3 +17,8 @@
 /mob/camera/Login()
 	..()
 	update_interface()
+
+/mob/camera/canmoveup()
+	return HasAbove(src)
+/mob/camera/canmovedown()
+	return HasBelow(src)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -133,7 +133,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		for(var/obj/effect/step_trigger/S in NewLoc)
 			S.Crossed(src)
 
-		return
+		return 1
 	loc = get_turf(src) //Get out of closets and such as a ghost
 	if((direct & NORTH) && y < world.maxy)
 		y++
@@ -451,6 +451,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		src.show_message("<span class='info'> Temperature: [round(environment.temperature-T0C)]&deg;C</span>", 1)
 
 /mob/dead/observer/canmoveup()
-	return !!GetAbove(src) //we're incorporeal after all
+	return HasAbove(src) //we're incorporeal after all
 /mob/dead/observer/canmovedown()
-	return !!GetBelow(src) //we're incorporeal after all
+	return HasBelow(src) //we're incorporeal after all

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -449,3 +449,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			src.show_message("<span class='warning'> Unknown: [round(unknown_concentration*100)]%</span>", 1)
 
 		src.show_message("<span class='info'> Temperature: [round(environment.temperature-T0C)]&deg;C</span>", 1)
+
+/mob/dead/observer/canmoveup()
+	return !!GetAbove(src) //we're incorporeal after all
+/mob/dead/observer/canmovedown()
+	return !!GetBelow(src) //we're incorporeal after all

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -526,3 +526,32 @@ var/const/GALOSHES_DONT_HELP = 8
 /mob/living/carbon/check_ear_prot()
 	if(head && (head.flags & HEADBANGPROTECT))
 		return 1
+
+/mob/living/carbon/canmoveup()
+	.=..()
+	if(!isnull(.))
+		return .
+	var/list/R=range(1,get_turf(src))
+	for(var/obj/structure/girder/G in R)
+		return 1
+	for(var/obj/structure/grille/G in R)
+		return 1
+	return null
+
+/mob/living/carbon/trymoveup()
+	.=..()
+	if(!isnull(.))
+		return . //so we know can we move up
+	var/obj/item/W = get_active_hand()
+	if(istype(W, /obj/item/weapon/extinguisher))
+		return W:move_z(src)
+	return null
+
+/mob/living/carbon/trymovedown()
+	.=..()
+	if(!isnull(.))
+		return . //so we know can we move up
+	var/obj/item/W = get_active_hand()
+	if(istype(W, /obj/item/weapon/extinguisher))
+		return W:move_z(src)
+	return null

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -544,7 +544,9 @@ var/const/GALOSHES_DONT_HELP = 8
 		return . //so we know can we move up
 	var/obj/item/W = get_active_hand()
 	if(istype(W, /obj/item/weapon/extinguisher))
-		return W:move_z(src)
+		var/F=W:move_z(src)
+		if(F)
+			return F
 	return null
 
 /mob/living/carbon/trymovedown()
@@ -553,5 +555,7 @@ var/const/GALOSHES_DONT_HELP = 8
 		return . //so we know can we move up
 	var/obj/item/W = get_active_hand()
 	if(istype(W, /obj/item/weapon/extinguisher))
-		return W:move_z(src)
+		var/F=W:move_z(src)
+		if(F)
+			return F
 	return null

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -24,6 +24,32 @@
 
 	return 0
 
+/mob/living/carbon/human/trymoveup()
+	.=..()
+	if(!isnull(.))
+		return .
+	if(istype(back, /obj/item/weapon/tank/jetpack) && isturf(loc)) //Second check is so you can't use a jetpack in a mech
+		var/obj/item/weapon/tank/jetpack/J = back
+		if(J.allow_thrust(0.01, src))
+			return 2
+	if(istype(wear_suit, /obj/item/clothing/suit/space/hardsuit) && isturf(loc)) //Second check is so you can't use a jetpack in a mech
+		var/obj/item/clothing/suit/space/hardsuit/C = wear_suit
+		if(C.jetpack)
+			if(C.jetpack.allow_thrust(0.01, src))
+				return 2
+/mob/living/carbon/human/trymovedown()
+	.=..()
+	if(!isnull(.))
+		return .
+	if(istype(back, /obj/item/weapon/tank/jetpack) && isturf(loc)) //Second check is so you can't use a jetpack in a mech
+		var/obj/item/weapon/tank/jetpack/J = back
+		if(J.allow_thrust(0.01, src))
+			return 2
+	if(istype(wear_suit, /obj/item/clothing/suit/space/hardsuit) && isturf(loc)) //Second check is so you can't use a jetpack in a mech
+		var/obj/item/clothing/suit/space/hardsuit/C = wear_suit
+		if(C.jetpack)
+			if(C.jetpack.allow_thrust(0.01, src))
+				return 2
 
 /mob/living/carbon/human/slip(var/s_amount, var/w_amount, var/obj/O, var/lube)
 	if(isobj(shoes) && (shoes.flags&NOSLIP) && !(lube&GALOSHES_DONT_HELP))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -806,3 +806,7 @@ var/list/ai_list = list()
 /mob/living/silicon/ai/attack_slime(mob/living/simple_animal/slime/user)
 	return
 
+/mob/living/silicon/ai/canmoveup()
+	return HasAbove(src)
+/mob/living/silicon/ai/canmovedown()
+	return HasBelow(src)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -76,21 +76,22 @@
 
 	var/initial = initial(user.sprint)
 	var/max_sprint = 50
-
-	if(user.cooldown && user.cooldown < world.timeofday) // 3 seconds
-		user.sprint = initial
-
-	for(var/i = 0; i < max(user.sprint, initial); i += 20)
-		var/turf/step = get_turf(get_step(user.eyeobj, direct))
-		if(step)
-			user.eyeobj.setLoc(step)
-
-	user.cooldown = world.timeofday + 5
-	if(user.acceleration)
-		user.sprint = min(user.sprint + 0.5, max_sprint)
+	if(direct)
+		if(user.cooldown && user.cooldown < world.timeofday) // 3 seconds
+			user.sprint = initial
+	
+		for(var/i = 0; i < max(user.sprint, initial); i += 20)
+			var/turf/step = get_turf(get_step(user.eyeobj, direct))
+			if(step)
+				user.eyeobj.setLoc(step)
+	
+		user.cooldown = world.timeofday + 5
+		if(user.acceleration)
+			user.sprint = min(user.sprint + 0.5, max_sprint)
+		else
+			user.sprint = initial
 	else
-		user.sprint = initial
-
+		user.eyeobj.setLoc(n)
 	user.cameraFollow = null
 
 	//user.unset_machine() //Uncomment this if it causes problems.

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -13,3 +13,29 @@
 	tally = speed
 
 	return tally+config.robot_delay
+
+/mob/living/silicon/robot/trymoveup()
+	.=..()
+	if(!isnull(.))
+		return .
+	if(module)
+		for(var/obj/item/weapon/tank/jetpack/J in module.modules)
+			if(J && istype(J, /obj/item/weapon/tank/jetpack))
+				if(J.allow_thrust(0.01))	return 1
+	if(module)
+		for(var/obj/item/weapon/extinguisher/E in module.modules)
+			if(E && istype(E, /obj/item/weapon/extinguisher))
+				return E.move_z()
+
+/mob/living/silicon/robot/trymovedown()
+	.=..()
+	if(!isnull(.))
+		return .
+	if(module)
+		for(var/obj/item/weapon/tank/jetpack/J in module.modules)
+			if(J && istype(J, /obj/item/weapon/tank/jetpack))
+				if(J.allow_thrust(0.01))	return 1
+	if(module)
+		for(var/obj/item/weapon/extinguisher/E in module.modules)
+			if(E && istype(E, /obj/item/weapon/extinguisher))
+				return E.move_z()

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -25,7 +25,9 @@
 	if(module)
 		for(var/obj/item/weapon/extinguisher/E in module.modules)
 			if(E && istype(E, /obj/item/weapon/extinguisher))
-				return E.move_z()
+				var/F=E.move_z()
+				if(F)
+					return F
 
 /mob/living/silicon/robot/trymovedown()
 	.=..()
@@ -38,4 +40,6 @@
 	if(module)
 		for(var/obj/item/weapon/extinguisher/E in module.modules)
 			if(E && istype(E, /obj/item/weapon/extinguisher))
-				return E.move_z()
+				var/F=E.move_z()
+				if(F)
+					return F

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -972,3 +972,46 @@ var/list/slot_equipment_priority = list( \
 	if(isliving(src))
 		spell.action.Grant(src)
 	return
+
+/mob/proc/canmoveup()//possibility
+	if(istype(loc,/obj)||istype(loc,/mob))
+		return 1 //there's something interesting going on
+	var/turf/above=GetAbove(src)
+	if(!istype(above,/turf/simulated/open_space)&&!istype(above,/turf/space))
+		return 0 //we can't pass through solid floors, can we? and also we can't go to null
+	if(istype(src,/mob/living/simple_animal)&&src:flying)
+		return 1 //no matter why it's flying, let's just suppose it can fly in every circumstance
+	if(has_gravity(src))
+		return //can't say if we can
+	if(Process_Spacemove(0))
+		return 1 //sure we can
+	return null //tis all for now, more for carbon
+/mob/proc/canmovedown()//possibility
+	if(istype(loc,/obj)||istype(loc,/mob))
+		return 1 //there's something interesting going on
+	var/turf/urturf=get_turf(src)
+	if(!istype(urturf,/turf/simulated/open_space)&&!istype(urturf,/turf/space))
+		return 0 //we can't pass through solid floors, can we? and also we can't go to null
+	if(istype(src,/mob/living/simple_animal)&&src:flying)
+		return 1 //no matter why it's flying, let's just suppose it can fly in every circumstance
+	if(has_gravity(src))
+		return 1 //idk maybe something is blocking our fall or we want to accelerate and probably avoid being damaged by fall
+	if(Process_Spacemove(0))
+		return 1 //sure we can
+	return null //tis all for now, more for carbon
+
+/mob/proc/trymoveup()//If we can and if we succeed
+	return canmoveup()
+/mob/proc/trymovedown()//If we can and if we succeed
+	return canmovedown()
+
+/mob/verb/moveUp()
+	set category="IC"
+	set name="Move up"
+	set desc="Try to move up"
+	trymoveup()&&Move(GetAbove(src))//,UP) //We don't want dir to be vertical, do we?
+/mob/verb/moveDown()
+	set category="IC"
+	set name="Move down"
+	set desc="Try to move down"
+	trymovedown()&&Move(GetBelow(src))//,DOWN) //We don't want dir to be vertical, do we?

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -989,6 +989,8 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/canmovedown()//possibility
 	if(istype(loc,/obj)||istype(loc,/mob))
 		return 1 //there's something interesting going on
+	if(!GetBelow(src))
+		return 0
 	var/turf/urturf=get_turf(src)
 	if(!istype(urturf,/turf/simulated/open_space)&&!istype(urturf,/turf/space))
 		return 0 //we can't pass through solid floors, can we? and also we can't go to null
@@ -1004,14 +1006,3 @@ var/list/slot_equipment_priority = list( \
 	return canmoveup()
 /mob/proc/trymovedown()//If we can and if we succeed
 	return canmovedown()
-
-/mob/verb/moveUp()
-	set category="IC"
-	set name="Move up"
-	set desc="Try to move up"
-	trymoveup()&&Move(GetAbove(src))//,UP) //We don't want dir to be vertical, do we?
-/mob/verb/moveDown()
-	set category="IC"
-	set name="Move down"
-	set desc="Try to move down"
-	trymovedown()&&Move(GetBelow(src))//,DOWN) //We don't want dir to be vertical, do we?

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -49,7 +49,7 @@
 		else
 			mob:swap_hand()*/
 	if(use_mz_hotkeys)
-		mob.moveUp()
+		moveUp()
 	else
 		swap_hand()
 	return
@@ -76,7 +76,7 @@
 		else if(W)
 			W.attack_self(mob)*/
 	if(use_mz_hotkeys)
-		mob.moveDown()
+		moveDown()
 	else
 		attack_self()
 	return
@@ -143,14 +143,49 @@
 			mob.control_object.loc = get_step(mob.control_object,direct)
 	return
 
+/client/verb/moveUp()
+	set category="IC"
+	set name="Move up"
+	set desc="Try to move up"
+	set src=usr
+	if(!mob)
+		usr<<"You don't have a body"
+		return
+	var/O=mob.trymoveup()
+	if(O)
+		usr<<"You try to move up"
+		if(Move(GetAbove(mob),0,O-1))
+			usr<<"You successfully moved up"
+		else
+			usr<<"You failed to move up"
+	else
+		usr<<"You're unable to move up right now"
 
-/client/Move(n, direct)
+/client/verb/moveDown()
+	set category="IC"
+	set name="Move down"
+	set desc="Try to move down"
+	set src=usr
+	if(!mob)
+		usr<<"You don't have a body"
+		return
+	var/O=mob.trymovedown()
+	if(O)
+		usr<<"You try to move down"
+		if(Move(GetBelow(mob),0,O-1))
+			usr<<"You successfully moved down"
+		else
+			usr<<"You failed to move down"
+	else
+		usr<<"You're unable to move down right now"
+
+/client/Move(n, direct, override_spessmove=0)
 	if(!mob)
 		return 0
 	if(mob.notransform)
 		return 0	//This is sota the goto stop mobs from moving var
 	if(mob.control_object)
-		return Move_object(direct)//&~(UP|DOWN))//only horizontal to avoid multi fuckery
+		return Move_object(direct)//&~(UP|DOWN))//only horizontal to avoid multiz fuckery
 	if(world.time < move_delay)
 		return 0
 	if(!isliving(mob))
@@ -169,29 +204,21 @@
 		if(L.incorporeal_move)	//Move though walls
 			Process_Incorpmove(direct)
 			return 0
-
 	if(Process_Grab())	return
-
 	if(mob.buckled)							//if we're buckled to something, tell it we moved.
 		return mob.buckled.relaymove(mob, direct)//&~(UP|DOWN)) //only horizontal for now to avoid multiz fuckery
-
 	if(mob.remote_control)					//we're controlling something, our movement is relayed to it
 		return mob.remote_control.relaymove(mob, direct)//&~(UP|DOWN)) //only horizontal for now to avoid multiz fuckery
-
 	if(!mob.canmove)
 		return 0
-
 	if(!mob.lastarea)
 		mob.lastarea = get_area(mob.loc)
-
 
 	if(isobj(mob.loc) || ismob(mob.loc))	//Inside an object, tell it we moved
 		var/atom/O = mob.loc
 		return O.relaymove(mob, direct)
-
-	if(!mob.Process_Spacemove(direct))
+	if(!mob.Process_Spacemove(direct)&&!override_spessmove)
 		return 0
-
 	if(isturf(mob.loc))
 
 		move_delay = world.time//set move delay
@@ -254,16 +281,13 @@
 							M.other_mobs = null
 							M.animate_movement = 2
 							return
-
 		if(mob.confused && IsEven(world.time))
 			step(mob, pick(cardinal))
 		else
 			. = ..()
-
 		moving = 0
 		if(mob && .)
 			mob.throwing = 0
-
 		return .
 
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -81,7 +81,7 @@ var/vessel_type = "station"
 		R.my_atom = W
 		src.reagents.trans_to(W,1+4*grav)
 		user<<"<span class='notice'>You propel yourself with water stream from [src]</span>"
-		return 1
+		return 2  //so we can override spessmove
 	user<<"<span class='warning'>[src] is empty!</span>"
 	return 0
 		/*var/turf/controllerlocation = locate(1, 1, usr.z)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -68,23 +68,30 @@ var/vessel_type = "station"
 					else
 						user << "\red The [vessel_type]'s gravity well keeps you in orbit!"
 
-/obj/item/weapon/extinguisher/proc/move_z(cardinal, mob/user as mob)
-	if(src.reagents.total_volume >= 1)
+/obj/item/weapon/extinguisher/proc/move_z(mob/user as mob)
+	if(safety)
+		return 0
+	var/grav=!!has_gravity(user)
+	if(src.reagents.total_volume >= 1+4*grav)
 		playsound(src.loc, 'sound/effects/extinguish.ogg', 75, 1, -3)
 		var/obj/effect/effect/water/W = PoolOrNew( /obj/effect/effect/water, get_turf(src) )
 		var/datum/reagents/R = new/datum/reagents(5)
 		if(!W) return
 		W.reagents = R
 		R.my_atom = W
-		src.reagents.trans_to(W,1)
-		var/turf/controllerlocation = locate(1, 1, usr.z)
+		src.reagents.trans_to(W,1+4*grav)
+		user<<"<span class='notice'>You propel yourself with water stream from [src]</span>"
+		return 1
+	user<<"<span class='warning'>[src] is empty!</span>"
+	return 0
+		/*var/turf/controllerlocation = locate(1, 1, usr.z)
 		switch(cardinal)
 			if (UP) // Going up!
 				for(var/obj/effect/landmark/zcontroller/controller in controllerlocation)
 					if (controller.up)
 						var/turf/T = locate(usr.x, usr.y, controller.up_target)
 						// You can only jetpack up if there's space above, and you're sitting on either hull (on the exterior), or space
-						//if(T && istype(T, /turf/space) && (istype(user.loc, /turf/space) || istype(user.loc, /turf/space/*/hull*/)))
+						//if(T && istype(T, /turf/space) && (istype(user.loc, /turf/space) || istype(user.loc, /turf/space/.../hull/)))
 						//check through turf contents to make sure there's nothing blocking the way
 						if(T && (istype(T, /turf/space) || istype(T, /turf/simulated/open_space)))
 							var/blocked = 0
@@ -117,5 +124,5 @@ var/vessel_type = "station"
 						else
 							user << "\red You bump into the [vessel_type]'s plating."
 					else
-						user << "\red The [vessel_type]'s gravity well keeps you in orbit!"
+						user << "\red The [vessel_type]'s gravity well keeps you in orbit!"*/
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -28,6 +28,12 @@
 	</tr>
 </table>
 		<div class="commit sansserif">
+		<h2 class="date">23 January 2017</h2>
+		<h3 class="author">Jammer312 updated:</h3>
+		<ul class="changes bgimages16">
+			<li class="tweak">Перемещение по этажам вынесено в вербы в раздел IC, там же можно включить старый режим, в котором кнопки смены рук и юзания предмета вместо своей функции перемещали по этажам</li>
+			<li class="rscadd">Различные мобы научились лазить по этажам, люди научились использовать встроенные в РИГ джетпаки, органики научились лазить по решеткам и каркасам стен, в отсутствие гравитации почти по всему</li>
+		</ul>
 		<h2 class="date">12 January 2017</h2>
 		<h3 class="author">Jammer312 updated:</h3>
 		<ul class="changes bgimages16">


### PR DESCRIPTION
Юбилейный #500 ПР.

Теперь перемещение завязано на вербы, которые находятся в разделе IC. При желании там же можно включить старый режим, когда вместо смены рук и активации предметов ты перемещался по уровням (toggle-mz-hotkeys).

Собственно, возможность перемещения теперь можно задать для каждого моба отдельно, в частности, теперь всякие карпы научились бегать по уровням вне зависимости от гравитации, а остальные просто научились.
В отсутствие гравитации при наличии чего-то, за что можно уцепиться, можно перемещаться по уроням.
Органики научились лазить по решеткам и недостроенным стенам(гирдерам).
Человеки научились летать на встроенных в РИГ джетпаках между этажами.
Борги научились пользоваться огнетушителями.
При наличии гравитации можно спускаться вниз, если получится (т.е. с кэтволков можно слезать вниз)
Теперь передвижение по этажам считается перемещением, т.е. ограничено скоростью передвижения моба.

ИИ разучился(а умел ли?) переключаться между этажами, и я пока не понял, почему, но т.к. у нас все равно камер на неосновных этажах нет, можно на это пока что забить.